### PR TITLE
Clean up examples for Ruff compliance

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example scripts for SpectAcoular."""

--- a/examples/basic_mic_geom_plot.py
+++ b/examples/basic_mic_geom_plot.py
@@ -1,14 +1,12 @@
 # ------------------------------------------------------------------------------
 # Copyright (c) Acoular Development Team.
 # ------------------------------------------------------------------------------
-"""
+"""Basic plotting with Bokeh.
+
 .. _basic_mic_geom_plot:
 
-Basic plotting with Bokeh
-=========================
-
-In this example, we are going to create a simple plot of a Microphone Array Geometry loaded from
-an XML file using the Acoular package and Bokeh for visualization.
+This example creates a simple plot of a microphone array geometry loaded
+from an XML file using Acoular and Bokeh.
 
 .. bokeh-plot:: ../examples/basic_mic_geom_plot.py
    :source-position: none
@@ -23,19 +21,22 @@ an XML file using the Acoular package and Bokeh for visualization.
 # First, we import the necessary modules.
 
 from pathlib import Path
+
+import acoular as ac
+
 from bokeh.io import show
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
 
-import acoular as ac
-
 # %%
-# Next, we set up the microphone geometry by using Acoular's :class:`~acoular.microphones.MicGeom` class.
-# For demonstration purposes, we will use a 64 channel Vogel's spiral microphone array geometry,
-# stored in an XML file that is part of the Acoular package. To locate the
-# `XML directory <https://github.com/acoular/acoular/tree/master/acoular/xml>`_ in the Acoular package,
-# we use the :class:`~pathlib.Path` object to dynamically construct the path relative to the
-# Acoular package location.
+# Next, we set up the microphone geometry with Acoular's
+# :class:`~acoular.microphones.MicGeom` class.
+# For demonstration purposes, we use a 64 channel Vogel's spiral microphone
+# array geometry stored in an XML file that is part of the Acoular package.
+# To locate the
+# `XML directory <https://github.com/acoular/acoular/tree/master/acoular/xml>`_
+# in the Acoular package, we use the :class:`~pathlib.Path` object to
+# dynamically construct the path relative to the Acoular package location.
 
 mics = ac.MicGeom(file=Path(ac.__file__).parent / 'xml' / 'tub_vogel64.xml')
 
@@ -56,18 +57,21 @@ figure = figure(
 
 
 # %%
-# The convenient way to provide data to a Bokeh :class:`~bokeh.plotting.Plot` is to use a
-# :class:`~bokeh.models.ColumnDataSource`, which is a data structure that allows us to easily update
-# the data in the plot. Since we create a 2D plot, we only need the x and y coordinates of the microphones.
+# A convenient way to provide data to a Bokeh
+# :class:`~bokeh.plotting.Plot` is to use a
+# :class:`~bokeh.models.ColumnDataSource`, which allows us to update the
+# data in the plot easily. Since we create a 2D plot, we only need the *x*
+# and *y* coordinates of the microphones.
 
 source = ColumnDataSource(data={"x": mics.pos_total[0], "y": mics.pos_total[1]})
 
 # %%
 # In addition, we need to decide which
 # `glyph <https://docs.bokeh.org/en/latest/docs/reference/models/glyphs.html#module-bokeh.models.glyphs>`_
-# to use. Glyphs are the basic building blocks of Bokeh plots, and they define how the data is visualized.
-# In this case, we will use the :meth:`~bokeh.plotting.figure.circle` method to create a
-# :class:`~bokeh.models.glyphs.Circle` to represent the microphones.
+# to use. Glyphs are the basic building blocks of Bokeh plots and define
+# how the data is visualized. In this case, we use the
+# :meth:`~bokeh.plotting.figure.circle` method to create a
+# :class:`~bokeh.models.glyphs.Circle` that represents the microphones.
 figure.circle(
     x='x',
     y='y',

--- a/examples/basic_mic_geom_plot.py
+++ b/examples/basic_mic_geom_plot.py
@@ -63,7 +63,7 @@ figure = figure(
 # data in the plot easily. Since we create a 2D plot, we only need the *x*
 # and *y* coordinates of the microphones.
 
-source = ColumnDataSource(data={"x": mics.pos_total[0], "y": mics.pos_total[1]})
+source = ColumnDataSource(data={'x': mics.pos_total[0], 'y': mics.pos_total[1]})
 
 # %%
 # In addition, we need to decide which

--- a/examples/basic_mic_geom_widgets.py
+++ b/examples/basic_mic_geom_widgets.py
@@ -130,15 +130,11 @@ figure.toolbar.active_tap = draw_tool
 # %%
 # Let's create a layout that contains the figure and the widgets.
 
-widget_column = column(
-    *numeric_widgets.values(), *data_table_widget.values(), width=400
-)
+widget_column = column(*numeric_widgets.values(), *data_table_widget.values(), width=400)
 layout = row(figure, widget_column)
 show(layout)  # Show the plot in a new browser window
 
 # %%
 # The following code is for Bokeh server apps only.
 
-curdoc().add_root(
-    layout
-)  # Add the layout to the current document for Bokeh server apps
+curdoc().add_root(layout)  # Add the layout to the current document for Bokeh server apps

--- a/examples/basic_mic_geom_widgets.py
+++ b/examples/basic_mic_geom_widgets.py
@@ -1,19 +1,15 @@
 # ------------------------------------------------------------------------------
 # Copyright (c) Acoular Development Team.
 # ------------------------------------------------------------------------------
-"""
+"""Creating widgets with SpectAcoular.
+
 .. _basic_mic_geom_widgets:
 
-Creating widgets with SpectAcoular
-==================================
-
-In this example, we are going to create an interactive plot of a Microphone Array Geometry with additional control widgets
-using the SpectAcoular package.
-
+This example creates an interactive plot of a microphone array geometry
+with additional control widgets using the SpectAcoular package.
 
 .. bokeh-plot:: ../examples/basic_mic_geom_widgets.py
    :source-position: none
-
 
 .. note::
     This example can be rendered as a standalone Bokeh document, but full interactivity
@@ -32,7 +28,6 @@ from pathlib import Path
 import acoular as ac
 import spectacoular as sp
 
-from pathlib import Path
 from bokeh.io import curdoc, show
 from bokeh.layouts import column, row
 from bokeh.models import ColumnDataSource, NumberEditor, PointDrawTool, TableColumn
@@ -67,19 +62,25 @@ glyph = figure.circle(
 # Create widgets for MicGeom
 # --------------------------
 #
-# The :class:`~acoular.microphones.MicGeom` class provides several attributes, known as traits, that can be used to
-# either provide additional information about the microphone array or to modify the geometry. In this example,
-# we focus on the most relevant ones for widget creation: :attr:`~acoular.microphones.MicGeom.num_mics`,
-# :attr:`~acoular.microphones.MicGeom.aperture`, and :attr:`~acoular.microphones.MicGeom.pos_total`.
+# The :class:`~acoular.microphones.MicGeom` class provides several
+# attributes, known as traits, that can either provide additional
+# information about the microphone array or modify the geometry. In this
+# example, we focus on the most relevant ones for widget creation:
+# :attr:`~acoular.microphones.MicGeom.num_mics`,
+# :attr:`~acoular.microphones.MicGeom.aperture`, and
+# :attr:`~acoular.microphones.MicGeom.pos_total`.
 
 # %%
-# Let's say we want to know about the number of microphones (:attr:`~acoular.microphones.MicGeom.num_mics`) and
-# the aperture of the microphone array (:attr:`~acoular.microphones.MicGeom.aperture`), we can use SpectAcoular's
-# :func:`~spectacoular.factory.get_widgets` function to translate each attribute into a Bokeh widget.
+# If we want to inspect the number of microphones
+# (:attr:`~acoular.microphones.MicGeom.num_mics`) and the aperture of the
+# microphone array (:attr:`~acoular.microphones.MicGeom.aperture`), we can
+# use SpectAcoular's :func:`~spectacoular.factory.get_widgets` function to
+# translate each attribute into a Bokeh widget.
 #
-# Defining each trait to widget mapping individually can become cumbersome, and not all
-# widgets are suitable for all traits. Therefore, SpectAcoular provides default widget mapping for
-# most of Acoular's classes.
+# Defining each trait to widget mapping individually can become
+# cumbersome, and not all widgets are suitable for all traits.
+# Therefore, SpectAcoular provides default widget mapping for most of
+# Acoular's classes.
 
 numeric_widgets = mics.get_widgets(
     {'aperture': NumericInput, 'num_mics': NumericInput},

--- a/examples/interactive_apps.py
+++ b/examples/interactive_apps.py
@@ -98,7 +98,7 @@ grid_grid = gridplot(list(sp.get_widgets(rg).values()), ncols=2, width=150)
 # *y* coordinates of the bottom-left grid corner, the width and height of
 # the grid, and the sound pressure to be displayed.
 
-source_plot = figure(title="Acoular Three Sources", tools="hover,reset,pan,wheel_zoom")
+source_plot = figure(title='Acoular Three Sources', tools='hover,reset,pan,wheel_zoom')
 
 cds = ColumnDataSource(
     data={

--- a/examples/interactive_apps.py
+++ b/examples/interactive_apps.py
@@ -1,30 +1,27 @@
 # ------------------------------------------------------------------------------
 # Copyright (c) Acoular Development Team.
 # ------------------------------------------------------------------------------
-"""
+"""Interactive server applications with SpectAcoular.
+
 .. _interactive_apps:
 
-Interactive Server Applications with SepctAcoular
-=================================================
-
-In many cases, a standalone HTML document is not sufficient to provide full interactivity, especially
-when computations are required on the Python side to update data shown in the Browser document.
-Bokeh provides a way to host applications that can be run in a web browser, allowing for
-interactivity and real-time updates.
+Standalone HTML documents are often not sufficient for full interactivity,
+especially when Python-side computations are needed to update displayed
+results. Bokeh can host applications in a web browser and provide
+real-time updates.
 
 .. image:: https://docs.bokeh.org/en/latest/_images/bokeh_serve.svg
     :width: 600px
     :align: center
     :alt: Bokeh Server Application (see: `Bokeh documentation <https://docs.bokeh.org/en/latest/docs/user_guide/server/app.html#ug-server-apps>`_)
 
-
-In this example, we are going to create an interactive application to visualize the Beamforming
-result for Acoular's
-`three sources example <https://www.acoular.org/auto_examples/introductory_examples/example_basic_beamforming.html#sphx-glr-auto-examples-introductory-examples-example-basic-beamforming-py>`_ .
-As seen by the HTML document below, changing the frequency or grid parameters will **not** result
-in an update of the plot, since the HTML document is static and does not allow for interaction with
-the Python code. Instead, it is necessary to run a Bokeh server application hosting the Python code
-to which the client can listen for updates of the data.
+This example creates an interactive application to visualize the
+beamforming result for Acoular's three sources example.
+See the `Acoular example documentation <https://www.acoular.org/auto_examples/introductory_examples/example_basic_beamforming.html>`_.
+As the HTML document below shows, changing the frequency or grid
+parameters will **not** update the plot because the document is static and
+cannot interact with the Python code. To get updates, the Python code must
+run in a Bokeh server application to which the client can listen.
 
 To start the Bokeh server, run the following command in the terminal:
 
@@ -32,10 +29,8 @@ To start the Bokeh server, run the following command in the terminal:
 
     $ bokeh serve --show examples/interactive_apps.py
 
-
 .. bokeh-plot:: ../examples/interactive_apps.py
    :source-position: none
-
 
 """
 
@@ -43,21 +38,20 @@ To start the Bokeh server, run the following command in the terminal:
 # Create three sources example
 # -----------------------------
 #
-# Let's begin with the necessary imports and setting up the simulation pipeline for the three sources example.
+# Let's begin with the necessary imports and the simulation pipeline
+# for the three sources example.
 
 from pathlib import Path
 
 import acoular as ac
 import spectacoular as sp
+
 from bokeh.io import curdoc
 from bokeh.layouts import column, gridplot, row
 from bokeh.models import ColumnDataSource, LinearColorMapper
 from bokeh.models.widgets import Slider
 from bokeh.palettes import viridis
 from bokeh.plotting import figure
-
-import acoular as ac
-import spectacoular as sp
 
 mg = ac.MicGeom(file=Path(ac.__file__).parent / 'xml' / 'array_64.xml')
 
@@ -66,9 +60,11 @@ three_sources = ac.demo.create_three_sources(mg)
 
 
 # %%
-# Next, we will define a rectangular grid (:class:`~acoular.grids.RectGrid`) discretizing the source area.
-# To obtain a source map at 4 kHz (one-third octave) asociated with the defined grid,
-# we will utilize conventional beamforming (:class:`~acoular.fbeamform.BeamformerBase`).
+# Next, we define a rectangular grid
+# (:class:`~acoular.grids.RectGrid`) that discretizes the source area.
+# To obtain a source map at 4 kHz (one-third octave) associated with the
+# defined grid, we use conventional beamforming
+# (:class:`~acoular.fbeamform.BeamformerBase`).
 
 # set up the rectangular grid
 rg = ac.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=-0.3, increment=0.01)
@@ -96,10 +92,11 @@ grid_grid = gridplot(list(sp.get_widgets(rg).values()), ncols=2, width=150)
 # Plot the beamforming result
 # ---------------------------
 #
-# To visualize the beamforming result, we will create figure and use Bokeh's
-# :class:`~bokeh.models.Image` glyph, which allows us to display 2D source mappings.
-# The :class:`~bokeh.models.Image` glyph requires us to specify the *x* and *y* coordinates of the bottom
-# left grid corner, the width and height of the grid, and the sound pressure to be displayed.
+# To visualize the beamforming result, we create a figure and use
+# Bokeh's :class:`~bokeh.models.Image` glyph, which displays 2D source
+# mappings. The :class:`~bokeh.models.Image` glyph requires the *x* and
+# *y* coordinates of the bottom-left grid corner, the width and height of
+# the grid, and the sound pressure to be displayed.
 
 source_plot = figure(title="Acoular Three Sources", tools="hover,reset,pan,wheel_zoom")
 
@@ -134,10 +131,12 @@ source_plot.image(
 # The Presenter class
 # -------------------
 #
-# SpectAcoular provides so-called Presenter classes to automatically handle updates of the
-# :class:`~bokeh.models.ColumnDataSource` data whenever the desired evaluation parameters change.
-# Here, we will use the :class:`~spectacoular.BeamformerPresenter` class. We choose `auto_update=True`,
-# which means that the data in the :class:`~bokeh.models.ColumnDataSource` will be updated automatically
+# SpectAcoular provides Presenter classes that automatically handle
+# updates of :class:`~bokeh.models.ColumnDataSource` data whenever the
+# desired evaluation parameters change. Here, we use the
+# :class:`~spectacoular.BeamformerPresenter` class with
+# ``auto_update=True``, which means that the data in the
+# :class:`~bokeh.models.ColumnDataSource` is updated automatically
 # whenever the internal state of the beamformer changes.
 
 bf_presenter = sp.BeamformerPresenter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,6 @@ extend-exclude = [
     "docs/_build",
     "docs/auto_examples",
     "docs/conf.py",
-    "examples",
     "tests",
     "src/spectacoular/apps",
 ]


### PR DESCRIPTION
# Summary
- add `examples/__init__.py` so `examples/` is treated as a regular package
- stop excluding `examples/` from Ruff in `pyproject.toml`
- fix Ruff findings in:
  - `examples/basic_mic_geom_plot.py`
  - `examples/basic_mic_geom_widgets.py`
  - `examples/interactive_apps.py`
- mostly documentation-oriented cleanup:
  - clearer module docstrings, wrapped long comment/doc lines, and minor wording fixes

# Issue linkage
#39 