### PR TITLE
Clean up `bf_example_app` for Ruff compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,11 @@ extend-exclude = [
     "docs/conf.py",
     "examples",
     "tests",
-    "src/spectacoular/apps",
+    "src/spectacoular/apps/data_viewer_app",
+    "src/spectacoular/apps/level_meter_app",
+    "src/spectacoular/apps/measurement_app",
+    "src/spectacoular/apps/micgeom_app",
+    "src/spectacoular/apps/rotating_example_app",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/spectacoular/apps/__init__.py
+++ b/src/spectacoular/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Bokeh application entry points shipped with SpectAcoular."""

--- a/src/spectacoular/apps/bf_example_app/__init__.py
+++ b/src/spectacoular/apps/bf_example_app/__init__.py
@@ -1,9 +1,12 @@
-import sys
+"""Bokeh entry point for the beamforming example application."""
+
 import subprocess
+import sys
 from pathlib import Path
 
 
 def main():
-    command = ["bokeh", "serve", Path(__file__).parent]
+    """Start the beamforming example as a Bokeh server application."""
+    command = ['bokeh', 'serve', Path(__file__).parent]
     command.extend(sys.argv[1:])
-    subprocess.run(command)
+    subprocess.run(command, check=False)  # noqa: S603

--- a/src/spectacoular/apps/bf_example_app/main.py
+++ b/src/spectacoular/apps/bf_example_app/main.py
@@ -10,40 +10,42 @@ Start from an installed package with:
 """
 
 from pathlib import Path
+
 import acoular as ac
 import spectacoular as sp
+
 import numpy as np
 
 # bokeh imports
 from bokeh.io import curdoc
-from bokeh.layouts import column, row, layout
-from bokeh.models.tools import BoxEditTool
+from bokeh.layouts import column, layout, row
 from bokeh.models import (
-    LinearColorMapper,
     ColorBar,
     ColumnDataSource,
-    Range1d,
     HoverTool,
+    LinearColorMapper,
+    Range1d,
     Spacer,
 )
+from bokeh.models.glyphs import Scatter
+from bokeh.models.tools import BoxEditTool
 from bokeh.models.widgets import (
-    Select,
-    Toggle,
-    RangeSlider,
     Div,
     NumberEditor,
-    TableColumn,
     NumberFormatter,
+    RangeSlider,
+    Select,
+    TableColumn,
+    Toggle,
 )
-from bokeh.models.glyphs import Scatter
+from bokeh.palettes import Spectral11, viridis
 from bokeh.plotting import figure
-from bokeh.palettes import viridis, Spectral11
 from bokeh.server.server import Server
 
-
 COLORS = list(Spectral11)
-RED = "#961400"
-BLUE = "#3288bd"
+RED = '#961400'
+BLUE = '#3288bd'
+MIN_SPL_DB = -300
 
 doc = curdoc()
 
@@ -114,59 +116,59 @@ sectordata = ColumnDataSource(data={"x": [], "y": [], "width": [], "height": []}
 
 
 # Beamforming Plot
-bfPlot = figure(
-    title="Source Map", tools="pan,wheel_zoom,reset", width=700, match_aspect=True
+bf_plot = figure(
+    title='Source Map', tools='pan,wheel_zoom,reset', width=700, match_aspect=True
 )
 # draw airfoil
-bfPlot.rect(
+bf_plot.rect(
     -0.38,
     0.0,
     0.2,
     0.5,
     alpha=1.0,
-    color="gray",
+    color='gray',
     fill_alpha=0.8,
     line_width=5,
-    line_color="#1e3246",
+    line_color='#1e3246',
 )
-bfPlot.rect(  # draw rect grid bounds
-    alpha=1.0, color="#d2d6da", fill_alpha=0, line_width=2, source=grid_data
+bf_plot.rect(  # draw rect grid bounds
+    alpha=1.0, color='#d2d6da', fill_alpha=0, line_width=2, source=grid_data
 )  # line_color="#213447")
-bfPlot.toolbar.logo = None
-bfPlot.xgrid.visible = False
-bfPlot.ygrid.visible = False
-colorMapper = LinearColorMapper(
+bf_plot.toolbar.logo = None
+bf_plot.xgrid.visible = False
+bf_plot.ygrid.visible = False
+color_mapper = LinearColorMapper(
     palette=viridis(100), low=40, high=50, low_color=(1, 1, 1, 0)
 )
-bfImage = bfPlot.image(
+bf_image = bf_plot.image(
     image="bfdata",
     x="x",
     y="y",
     dw="dw",
     dh="dh",
     alpha=0.9,
-    color_mapper=colorMapper,
+    color_mapper=color_mapper,
     source=bv.cdsource,
-    anchor="bottom_left",
-    origin="bottom_left",
+    anchor='bottom_left',
+    origin='bottom_left',
 )
-bfPlot.add_layout(
-    ColorBar(color_mapper=colorMapper, location=(0, 0), title="dB", title_standoff=10),
-    "right",
+bf_plot.add_layout(
+    ColorBar(color_mapper=color_mapper, location=(0, 0), title='dB', title_standoff=10),
+    'right',
 )
 mic_layout = sp.layouts.MicGeomComponent(
-    glyph=Scatter(marker="circle_cross", x="xi", y="yi", size=15, fill_alpha=0.2),
+    glyph=Scatter(marker='circle_cross', x='xi', y='yi', size=15, fill_alpha=0.2),
     presenter=mgp,
-    figure=bfPlot,
+    figure=bf_plot,
 )
-bfPlot.add_tools(
+bf_plot.add_tools(
     HoverTool(
         tooltips=[
-            ("L_p (dB)", "@bfdata"),
-            ("mic", "@channels"),
+            ('L_p (dB)', '@bfdata'),
+            ('mic', '@channels'),
         ],
-        mode="mouse",
-        renderers=[bfImage, mic_layout._glyph_renderer],
+        mode='mouse',
+        renderers=[bf_image, mic_layout._glyph_renderer],  # noqa: SLF001
     )
 )
 
@@ -224,8 +226,8 @@ freqplot.xaxis.ticker = f_ticks
 freqplot.x_range = Range1d(20, 20000)
 freqplot.y_range = Range1d(0, 120)
 freqplot.xaxis.major_label_overrides = f_ticks_override
-frLine = freqplot.multi_line(
-    "freqs", "amp", color="colors", alpha=0.0, line_width=3, source=freqdata
+fr_line = freqplot.multi_line(
+    'freqs', 'amp', color='colors', alpha=0.0, line_width=3, source=freqdata
 )
 
 
@@ -247,47 +249,47 @@ beamformer_dict = {
 }
 
 # create Select Button to select Beamforming Algorithm
-beamformerSelector = Select(
-    title="Beamforming Method:",
+beamformer_selector = Select(
+    title='Beamforming Method:',
     options=list(beamformer_dict.keys()),
-    value=list(beamformer_dict.keys())[0],
+    value=next(iter(beamformer_dict.keys())),
     height=75,
-    sizing_mode="stretch_width",
+    sizing_mode='stretch_width',
 )
 
 # use additional classes for data evaluation/view
-bv.trait_widget_args.update({"num": {"width": 40}, "freq": {"width": 100}})
+bv.trait_widget_args.update({'num': {'width': 40}, 'freq': {'width': 100}})
 # get widgets to control settings
-tsWidgets = ts.get_widgets()
-mgWidgets = mic_layout.widgets
-envWidgets = env.get_widgets()
-calWidgets = cal.get_widgets()
-psWidgets = ps.get_widgets()
-rgWidgets = rg.get_widgets()
-stWidgets = st.get_widgets()
-bbWidgets = bb.get_widgets()
-bvWidgets = bv.get_widgets()
-tsWidgets.pop("invalid_channels")
+ts_widgets = ts.get_widgets()
+mg_widgets = mic_layout.widgets
+env_widgets = env.get_widgets()
+cal_widgets = cal.get_widgets()
+ps_widgets = ps.get_widgets()
+rg_widgets = rg.get_widgets()
+st_widgets = st.get_widgets()
+bb_widgets = bb.get_widgets()
+bv_widgets = bv.get_widgets()
+ts_widgets.pop('invalid_channels')
 
-invalid_widget = mgWidgets["invalid_channels"]
+invalid_widget = mg_widgets['invalid_channels']
 ts.set_widgets(invalid_channels=invalid_widget)
 cal.set_widgets(invalid_channels=invalid_widget)
 
 settings_dict = {
-    "Time Data": tsWidgets,
-    "Microphone Geometry": mgWidgets,
-    "Environment": envWidgets,
-    "Calibration": calWidgets,
-    "FFT/CSM": psWidgets,
-    "Focus Grid": rgWidgets,
-    "Steering Vector": stWidgets,
-    "Beamforming Method": bbWidgets,
+    'Time Data': ts_widgets,
+    'Microphone Geometry': mg_widgets,
+    'Environment': env_widgets,
+    'Calibration': cal_widgets,
+    'FFT/CSM': ps_widgets,
+    'Focus Grid': rg_widgets,
+    'Steering Vector': st_widgets,
+    'Beamforming Method': bb_widgets,
 }
 
 
 # %% Widgets for display
 
-dynamicSlider = RangeSlider(
+dynamic_slider = RangeSlider(
     start=0,
     end=120,
     step=1.0,
@@ -296,11 +298,11 @@ dynamicSlider = RangeSlider(
     height=50,
     title="Dynamic Range",
 )
-splSlider = RangeSlider(
+spl_slider = RangeSlider(
     start=0, end=140, step=1.0, value=(10, 120), width=350, height=50, title="SPL Range"
 )
 
-freqSlider = RangeSlider(
+freq_slider = RangeSlider(
     start=20,
     end=20000,
     step=1.0,
@@ -311,35 +313,36 @@ freqSlider = RangeSlider(
 )
 
 
-def dynamicSlider_callback(attr, old, new):
-    (colorMapper.low, colorMapper.high) = dynamicSlider.value
+def dynamic_slider_callback(_attr, _old, _new):
+    """Update the source-map color range."""
+    color_mapper.low, color_mapper.high = dynamic_slider.value
 
 
-dynamicSlider.on_change("value", dynamicSlider_callback)
+dynamic_slider.on_change('value', dynamic_slider_callback)
 
 
-def splSlider_callback(attr, old, new):
-    # adjust the y limits of the frequency plot
-    freqplot.y_range.start, freqplot.y_range.end = splSlider.value
+def spl_slider_callback(_attr, _old, _new):
+    """Update the y-axis limits of the frequency plot."""
+    freqplot.y_range.start, freqplot.y_range.end = spl_slider.value
 
 
-splSlider.on_change("value", splSlider_callback)
+spl_slider.on_change('value', spl_slider_callback)
 
 
-def freqSlider_callback(attr, old, new):
-    # adjust the x limits of the frequency plot
-    freqplot.x_range.start, freqplot.x_range.end = freqSlider.value
+def freq_slider_callback(_attr, _old, _new):
+    """Update the x-axis limits of the frequency plot."""
+    freqplot.x_range.start, freqplot.x_range.end = freq_slider.value
 
 
-freqSlider.on_change("value", freqSlider_callback)
+freq_slider.on_change('value', freq_slider_callback)
 
 # create Button to trigger beamforming result calculation
-calcButton = Toggle(button_type="primary", width=125, height=50, label="Calculate")
-sp.set_calc_button_callback(bv.update, calcButton)
+calc_button = Toggle(button_type='primary', width=125, height=50, label='Calculate')
+sp.set_calc_button_callback(bv.update, calc_button)
 
 
-def update_grid(attr, old, new):
-    """update grid data source when grid settings change"""
+def update_grid(_attr, _old, _new):
+    """Update grid data source when grid settings change."""
     grid_data.data = {
         # x and y are the centers of the rectangle!
         "x": [(rg.x_max + rg.x_min) / 2],
@@ -349,57 +352,54 @@ def update_grid(attr, old, new):
     }
 
 
-rgWidgets["x_min"].on_change("value", update_grid)
-rgWidgets["x_max"].on_change("value", update_grid)
-rgWidgets["y_min"].on_change("value", update_grid)
-rgWidgets["y_max"].on_change("value", update_grid)
+rg_widgets['x_min'].on_change('value', update_grid)
+rg_widgets['x_max'].on_change('value', update_grid)
+rg_widgets['y_min'].on_change('value', update_grid)
+rg_widgets['y_max'].on_change('value', update_grid)
 
 
 # %% Property Tabs
-selectedBfWidgets = column(*bbWidgets.values(), height=1000)
+selected_bf_widgets = column(*bb_widgets.values(), height=1000)
 
 # create Select Button to select Beamforming Algorithm
-settingSelector = Select(
-    title="Select Setting",
+setting_selector = Select(
+    title='Select Setting',
     options=list(settings_dict.keys()),
-    value=list(settings_dict.keys())[0],
+    value=next(iter(settings_dict.keys())),
     height=75,
 )
 
-selectedSettingCol = column(list(settings_dict["Time Data"].values()), height=1000)
+selected_setting_col = column(list(settings_dict['Time Data'].values()), height=1000)
 
 
-def select_setting_handler(attr, old, new):
-    """changes column layout (changes displayed widgets)
-    according to selected Acoular object
-    """
-    # print(attr,old,new)
-    if not new == "Beamforming Method":
-        selectedSettingCol.children = list(settings_dict[new].values())
+def select_setting_handler(_attr, _old, new):
+    """Change the displayed widget column for the selected Acoular object."""
+    if new != 'Beamforming Method':
+        selected_setting_col.children = list(settings_dict[new].values())
     else:
-        selectedSettingCol.children = selectedBfWidgets.children
+        selected_setting_col.children = selected_bf_widgets.children
 
 
-settingSelector.on_change("value", select_setting_handler)
+setting_selector.on_change('value', select_setting_handler)
 
 
-def beamformer_handler(attr, old, new):
+def beamformer_handler(_attr, _old, new):
+    """Switch the active beamformer and its settings widgets."""
     bv.source = beamformer_dict.get(new)[0]
-    # if dropdown.value == "bbWidgets"
-    selectedBfWidgets.children = list(beamformer_dict.get(new)[1].values())
-    if settingSelector.value == "Beamforming Method":
-        selectedSettingCol.children = selectedBfWidgets.children
-    # print(selectedBfWidgets.children)
+    selected_bf_widgets.children = list(beamformer_dict.get(new)[1].values())
+    if setting_selector.value == 'Beamforming Method':
+        selected_setting_col.children = selected_bf_widgets.children
 
 
-beamformerSelector.on_change("value", beamformer_handler)
+beamformer_selector.on_change('value', beamformer_handler)
 
 
 # %% Integration sector
-def integrate_result(attr, old, new):
+def integrate_result(_attr, _old, _new):
+    """Update the integrated sector spectrum."""
     numsectors = len(sectordata.data["x"])
     if numsectors > 0:
-        frLine.glyph.line_alpha = 0.8
+        fr_line.glyph.line_alpha = 0.8
         famp = []
         ffreq = []
         colors = []
@@ -419,21 +419,21 @@ def integrate_result(attr, old, new):
             if sector[0] >= sector[2] or sector[1] >= sector[3]:
                 continue
             specamp = ac.L_p(bv.source.integrate(sector))
-            specamp[specamp < -300] = np.nan
+            specamp[specamp < MIN_SPL_DB] = np.nan
             famp.append(specamp)
             ffreq.append(ps.fftfreq())
             colors.append(COLORS[i])
         if famp:
             freqdata.data = {"amp": famp, "freqs": ffreq, "colors": colors}
         else:
-            frLine.glyph.line_alpha = 0.0
+            fr_line.glyph.line_alpha = 0.0
             freqdata.data = {
                 "freqs": [np.array(f_ticks)],
                 "amp": [np.array([0] * len(f_ticks))],
                 "colors": ["white"],
             }
     else:
-        frLine.glyph.line_alpha = 0.0  # make transparent if no integration sector exist
+        fr_line.glyph.line_alpha = 0.0  # make transparent if no integration sector exist
         freqdata.data = {
             "freqs": [np.array(f_ticks)],
             "amp": [np.array([0] * len(f_ticks))],
@@ -441,7 +441,7 @@ def integrate_result(attr, old, new):
         }
 
 
-isector = bfPlot.rect(
+isector = bf_plot.rect(
     "x",
     "y",
     "width",
@@ -455,7 +455,7 @@ isector = bfPlot.rect(
 tool = BoxEditTool(
     renderers=[isector], num_objects=len(COLORS)
 )  # allow only as many boxes as Colors
-bfPlot.add_tools(tool)
+bf_plot.add_tools(tool)
 sectordata.on_change("data", integrate_result)
 bv.cdsource.on_change(
     "data", integrate_result
@@ -464,16 +464,25 @@ bv.cdsource.on_change(
 # %% Instructions
 
 instruction_calculation = Div(
-    text="""<p><b>Calculate Source Map:</b></p> <b>Select a desired beamforming method</b> via the "Beamforming Method" widget and <b>press the Calculate Button</b>.
-Depending on the method, this may take some time. You may also want to change the desired frequency and bandwith of interest with the "freq" and "num" Textfield widget.
-"""
+    text=(
+        '<p><b>Calculate Source Map:</b></p>'
+        ' <b>Select a desired beamforming method</b> via the "Beamforming Method" widget '
+        'and <b>press the Calculate Button</b>. Depending on the method, this may take '
+        'some time. You may also want to change the desired frequency and bandwith of '
+        'interest with the "freq" and "num" text field widgets.'
+    )
 )
 
 instruction_sector_integration = Div(
-    text="""<p><b>Integrate over Source Map Region:</b></p> <b>Select the "Box Edit Tool"</b> in the upper right corner of the source map figure after calculating the source map.
-<b>Hold down the shift key to draw an integration sector</b> in the Source Map. A sector-integrated spectrum should appear. One can <b>remove the sector by pressing the Backspace key</b>.
-If the rectangle extends beyond the source-map grid, it is clipped to the valid grid bounds automatically.
-"""
+    text=(
+        '<p><b>Integrate over Source Map Region:</b></p>'
+        ' <b>Select the "Box Edit Tool"</b> in the upper right corner of the source map '
+        'figure after calculating the source map. <b>Hold down the shift key to draw an '
+        'integration sector</b> in the source map. A sector-integrated spectrum should '
+        'appear. You can <b>remove the sector by pressing the Backspace key</b>. If the '
+        'rectangle extends beyond the source-map grid, it is clipped to the valid grid '
+        'bounds automatically.'
+    )
 )
 
 
@@ -481,28 +490,28 @@ If the rectangle extends beyond the source-map grid, it is clipped to the valid 
 
 left_layout = layout(
     [
-        [Spacer(width=40), calcButton, *bvWidgets.values(), dynamicSlider],
-        [bfPlot],
+        [Spacer(width=40), calc_button, *bv_widgets.values(), dynamic_slider],
+        [bf_plot],
     ]
 )
 
 center_layout = layout(
     [
-        [Spacer(width=40), splSlider, Spacer(width=20), freqSlider],
+        [Spacer(width=40), spl_slider, Spacer(width=20), freq_slider],
         [freqplot],
     ]
 )
 
 right_layout = column(
-    beamformerSelector,
-    settingSelector,
+    beamformer_selector,
+    setting_selector,
     Spacer(height=20),
-    selectedSettingCol,
+    selected_setting_col,
     sizing_mode="stretch_width",
 )
-instructionsCol = column(instruction_calculation, instruction_sector_integration)
+instructions_col = column(instruction_calculation, instruction_sector_integration)
 layout = column(
-    instructionsCol,
+    instructions_col,
     Spacer(height=50),
     row(left_layout, Spacer(width=10), center_layout, Spacer(width=20), right_layout),
 )
@@ -510,15 +519,15 @@ layout = column(
 
 # make Document
 def server_doc(doc):
+    """Add the beamforming application layout to a Bokeh document."""
     doc.add_root(layout)
-    doc.title = "Frequency Domain Beamforming App"
+    doc.title = 'Frequency Domain Beamforming App'
 
 
-if __name__ == "__main__":
-    server = Server({"/": server_doc})
+if __name__ == '__main__':
+    server = Server({'/': server_doc})
     server.start()
-    print("Opening application on http://localhost:5006/")
-    server.io_loop.add_callback(server.show, "/")
+    server.io_loop.add_callback(server.show, '/')
     server.io_loop.start()
 else:
     doc = curdoc()

--- a/src/spectacoular/apps/bf_example_app/main.py
+++ b/src/spectacoular/apps/bf_example_app/main.py
@@ -515,6 +515,7 @@ def server_doc(doc):
 if __name__ == '__main__':
     server = Server({'/': server_doc})
     server.start()
+    print('Opening application on http://localhost:5006/')  # noqa: T201
     server.io_loop.add_callback(server.show, '/')
     server.io_loop.start()
 else:

--- a/src/spectacoular/apps/bf_example_app/main.py
+++ b/src/spectacoular/apps/bf_example_app/main.py
@@ -52,21 +52,21 @@ doc = curdoc()
 # %% Build processing chain
 invalid = [1, 7]
 ts = sp.MaskedTimeSamples(
-    file=Path(__file__).parent.parent / "example_data.h5",
+    file=Path(__file__).parent.parent / 'example_data.h5',
     invalid_channels=invalid,
     start=0,
     stop=16000,
 )
 cal = sp.Calib(
     source=ts,
-    file=Path(__file__).parent / "example_calib.xml",
+    file=Path(__file__).parent / 'example_calib.xml',
     invalid_channels=ts.invalid_channels,
 )
 mg = sp.MicGeom(
-    file=Path(ac.__file__).parent / "xml" / "array_56.xml",
+    file=Path(ac.__file__).parent / 'xml' / 'array_56.xml',
     invalid_channels=ts.invalid_channels,
 )
-ps = sp.PowerSpectra(source=cal, block_size=1024, overlap="50%")
+ps = sp.PowerSpectra(source=cal, block_size=1024, overlap='50%')
 rg = sp.RectGrid(x_min=-0.6, x_max=-0.1, y_min=-0.3, y_max=0.3, z=0.68, increment=0.01)
 env = sp.Environment(c=346.04)
 st = sp.SteeringVector(grid=rg, mics=mg, env=env)
@@ -83,8 +83,8 @@ bdp = sp.BeamformerDamasPlus(freq_data=ps, n_iter=100)
 bo = sp.BeamformerOrth(freq_data=ps, eva_list=list(range(38, 54)))
 bs = sp.BeamformerCleansc(freq_data=ps, steer=st, r_diag=True)
 bl = sp.BeamformerClean(freq_data=ps, n_iter=100)
-bcmf = sp.BeamformerCMF(freq_data=ps, steer=st, method="LassoLarsBIC")
-bgib = sp.BeamformerGIB(freq_data=ps, steer=st, method="LassoLars", n=10)
+bcmf = sp.BeamformerCMF(freq_data=ps, steer=st, method='LassoLarsBIC')
+bgib = sp.BeamformerGIB(freq_data=ps, steer=st, method='LassoLars', n=10)
 
 bv = sp.BeamformerPresenter(source=bb, num=3, freq=4000.0)
 mgp = sp.MicGeomPresenter(source=mg, auto_update=True)
@@ -96,29 +96,27 @@ mgp.update()
 grid_data = ColumnDataSource(
     data={
         # x and y are the centers of the rectangle!
-        "x": [(rg.x_max + rg.x_min) / 2],
-        "y": [(rg.y_max + rg.y_min) / 2],
-        "width": [rg.x_max - rg.x_min],
-        "height": [rg.y_max - rg.y_min],
+        'x': [(rg.x_max + rg.x_min) / 2],
+        'y': [(rg.y_max + rg.y_min) / 2],
+        'width': [rg.x_max - rg.x_min],
+        'height': [rg.y_max - rg.y_min],
     }
 )
 
 f_ticks = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
 freqdata = ColumnDataSource(
     data={
-        "freqs": [np.array(f_ticks)],  # initialize
-        "amp": [np.array([0] * len(f_ticks))],
-        "colors": ["white"],
+        'freqs': [np.array(f_ticks)],  # initialize
+        'amp': [np.array([0] * len(f_ticks))],
+        'colors': ['white'],
     }
 )
 
-sectordata = ColumnDataSource(data={"x": [], "y": [], "width": [], "height": []})
+sectordata = ColumnDataSource(data={'x': [], 'y': [], 'width': [], 'height': []})
 
 
 # Beamforming Plot
-bf_plot = figure(
-    title='Source Map', tools='pan,wheel_zoom,reset', width=700, match_aspect=True
-)
+bf_plot = figure(title='Source Map', tools='pan,wheel_zoom,reset', width=700, match_aspect=True)
 # draw airfoil
 bf_plot.rect(
     -0.38,
@@ -137,15 +135,13 @@ bf_plot.rect(  # draw rect grid bounds
 bf_plot.toolbar.logo = None
 bf_plot.xgrid.visible = False
 bf_plot.ygrid.visible = False
-color_mapper = LinearColorMapper(
-    palette=viridis(100), low=40, high=50, low_color=(1, 1, 1, 0)
-)
+color_mapper = LinearColorMapper(palette=viridis(100), low=40, high=50, low_color=(1, 1, 1, 0))
 bf_image = bf_plot.image(
-    image="bfdata",
-    x="x",
-    y="y",
-    dw="dw",
-    dh="dh",
+    image='bfdata',
+    x='x',
+    y='y',
+    dw='dw',
+    dh='dh',
     alpha=0.9,
     color_mapper=color_mapper,
     source=bv.cdsource,
@@ -175,77 +171,75 @@ bf_plot.add_tools(
 
 # set up widgets for Microphone Geometry
 editor = NumberEditor()
-formatter = NumberFormatter(format="0.00")
+formatter = NumberFormatter(format='0.00')
 mpos_columns = [
-    TableColumn(field="x", title="x/m", editor=editor, formatter=formatter),
-    TableColumn(field="y", title="x/m", editor=editor, formatter=formatter),
-    TableColumn(field="z", title="x/m", editor=editor, formatter=formatter),
+    TableColumn(field='x', title='x/m', editor=editor, formatter=formatter),
+    TableColumn(field='y', title='x/m', editor=editor, formatter=formatter),
+    TableColumn(field='z', title='x/m', editor=editor, formatter=formatter),
 ]
 mic_layout.mics_trait_widget_args.update(
     {
-        "pos_total": {
-            "width": 280,
-            "editable": True,
-            "transposed": True,
-            "columns": mpos_columns,
+        'pos_total': {
+            'width': 280,
+            'editable': True,
+            'transposed': True,
+            'columns': mpos_columns,
         },
-        "invalid_channels": {
-            "width": 280,
-            "options": [str(i) for i in range(mg.pos_total.shape[1])],
+        'invalid_channels': {
+            'width': 280,
+            'options': [str(i) for i in range(mg.pos_total.shape[1])],
         },
     }
 )
 
 # FrequencySignalPlot
 f_ticks_override = {
-    20: "0.02",
-    50: "0.05",
-    100: "0.1",
-    200: "0.2",
-    500: "0.5",
-    1000: "1",
-    2000: "2",
-    5000: "5",
-    10000: "10",
-    20000: "20",
+    20: '0.02',
+    50: '0.05',
+    100: '0.1',
+    200: '0.2',
+    500: '0.5',
+    1000: '1',
+    2000: '2',
+    5000: '5',
+    10000: '10',
+    20000: '20',
 }
 freqplot = figure(
-    title="Sector-Integrated Spectrum",
+    title='Sector-Integrated Spectrum',
     width=800,
     match_aspect=True,
-    x_axis_type="log",
-    x_axis_label="f / kHz",
-    y_axis_label="SPL / dB",
+    x_axis_type='log',
+    x_axis_label='f / kHz',
+    y_axis_label='SPL / dB',
 )  # tooltips=TOOLTIPS)
 freqplot.toolbar.logo = None
-freqplot.xaxis.axis_label_text_font_style = "normal"
-freqplot.yaxis.axis_label_text_font_style = "normal"
-freqplot.xgrid.minor_grid_line_color = "navy"
+freqplot.xaxis.axis_label_text_font_style = 'normal'
+freqplot.yaxis.axis_label_text_font_style = 'normal'
+freqplot.xgrid.minor_grid_line_color = 'navy'
 freqplot.xgrid.minor_grid_line_alpha = 0.05
 freqplot.xaxis.ticker = f_ticks
 freqplot.x_range = Range1d(20, 20000)
 freqplot.y_range = Range1d(0, 120)
 freqplot.xaxis.major_label_overrides = f_ticks_override
-fr_line = freqplot.multi_line(
-    'freqs', 'amp', color='colors', alpha=0.0, line_width=3, source=freqdata
-)
+fr_line = freqplot.multi_line('freqs', 'amp', color='colors', alpha=0.0, line_width=3, source=freqdata)
 
 
 # %% widgets
 
 beamformer_dict = {
-    "Conventional Beamforming": (bb, bb.get_widgets()),
-    "Functional Beamforming": (bf, bf.get_widgets()),
-    "Capon Beamforming": (bc, bc.get_widgets()),
-    "Eigenvalue Beamforming": (be, be.get_widgets()),
-    "Music Beamforming": (bm, bm.get_widgets()),
-    "Damas Deconvolution": (bd, bd.get_widgets()),
-    "DamasPlus Deconvolution": (bdp, bdp.get_widgets()),
-    "Orthogonal Beamforming": (bo, bo.get_widgets()),
-    "CleanSC Deconvolution": (bs, bs.get_widgets()),
-    "Clean Deconvolution": (bl, bl.get_widgets()),
-    "CMF": (bcmf, bcmf.get_widgets()),
-    "GIB": (bgib, bgib.get_widgets()),
+    'Conventional Beamforming': (bb, bb.get_widgets()),
+    'Functional Beamforming': (bf, bf.get_widgets()),
+    'Capon Beamforming': (bc, bc.get_widgets()),
+    'Eigenvalue Beamforming': (be, be.get_widgets()),
+    'Music Beamforming': (bm, bm.get_widgets()),
+    'Damas Deconvolution': (bd, bd.get_widgets()),
+    'DamasPlus Deconvolution': (bdp, bdp.get_widgets()),
+    'Orthogonal Beamforming': (bo, bo.get_widgets()),
+    'CleanSC Deconvolution': (bs, bs.get_widgets()),
+    'Clean Deconvolution': (bl, bl.get_widgets()),
+    'CMF': (bcmf, bcmf.get_widgets()),
+    'GIB': (bgib, bgib.get_widgets()),
 }
 
 # create Select Button to select Beamforming Algorithm
@@ -296,11 +290,9 @@ dynamic_slider = RangeSlider(
     value=(40, 50),
     width=220,
     height=50,
-    title="Dynamic Range",
+    title='Dynamic Range',
 )
-spl_slider = RangeSlider(
-    start=0, end=140, step=1.0, value=(10, 120), width=350, height=50, title="SPL Range"
-)
+spl_slider = RangeSlider(start=0, end=140, step=1.0, value=(10, 120), width=350, height=50, title='SPL Range')
 
 freq_slider = RangeSlider(
     start=20,
@@ -309,7 +301,7 @@ freq_slider = RangeSlider(
     value=(20, 20000),
     width=350,
     height=50,
-    title="Frequency Range",
+    title='Frequency Range',
 )
 
 
@@ -345,10 +337,10 @@ def update_grid(_attr, _old, _new):
     """Update grid data source when grid settings change."""
     grid_data.data = {
         # x and y are the centers of the rectangle!
-        "x": [(rg.x_max + rg.x_min) / 2],
-        "y": [(rg.y_max + rg.y_min) / 2],
-        "width": [rg.x_max - rg.x_min],
-        "height": [rg.y_max - rg.y_min],
+        'x': [(rg.x_max + rg.x_min) / 2],
+        'y': [(rg.y_max + rg.y_min) / 2],
+        'width': [rg.x_max - rg.x_min],
+        'height': [rg.y_max - rg.y_min],
     }
 
 
@@ -397,7 +389,7 @@ beamformer_selector.on_change('value', beamformer_handler)
 # %% Integration sector
 def integrate_result(_attr, _old, _new):
     """Update the integrated sector spectrum."""
-    numsectors = len(sectordata.data["x"])
+    numsectors = len(sectordata.data['x'])
     if numsectors > 0:
         fr_line.glyph.line_alpha = 0.8
         famp = []
@@ -406,10 +398,10 @@ def integrate_result(_attr, _old, _new):
         for i in range(numsectors):
             sector = np.array(
                 [
-                    sectordata.data["x"][i] - sectordata.data["width"][i] / 2,
-                    sectordata.data["y"][i] - sectordata.data["height"][i] / 2,
-                    sectordata.data["x"][i] + sectordata.data["width"][i] / 2,
-                    sectordata.data["y"][i] + sectordata.data["height"][i] / 2,
+                    sectordata.data['x'][i] - sectordata.data['width'][i] / 2,
+                    sectordata.data['y'][i] - sectordata.data['height'][i] / 2,
+                    sectordata.data['x'][i] + sectordata.data['width'][i] / 2,
+                    sectordata.data['y'][i] + sectordata.data['height'][i] / 2,
                 ]
             )
             sector[0] = np.clip(sector[0], rg.x_min, rg.x_max)
@@ -424,42 +416,38 @@ def integrate_result(_attr, _old, _new):
             ffreq.append(ps.fftfreq())
             colors.append(COLORS[i])
         if famp:
-            freqdata.data = {"amp": famp, "freqs": ffreq, "colors": colors}
+            freqdata.data = {'amp': famp, 'freqs': ffreq, 'colors': colors}
         else:
             fr_line.glyph.line_alpha = 0.0
             freqdata.data = {
-                "freqs": [np.array(f_ticks)],
-                "amp": [np.array([0] * len(f_ticks))],
-                "colors": ["white"],
+                'freqs': [np.array(f_ticks)],
+                'amp': [np.array([0] * len(f_ticks))],
+                'colors': ['white'],
             }
     else:
         fr_line.glyph.line_alpha = 0.0  # make transparent if no integration sector exist
         freqdata.data = {
-            "freqs": [np.array(f_ticks)],
-            "amp": [np.array([0] * len(f_ticks))],
-            "colors": ["white"],
+            'freqs': [np.array(f_ticks)],
+            'amp': [np.array([0] * len(f_ticks))],
+            'colors': ['white'],
         }
 
 
 isector = bf_plot.rect(
-    "x",
-    "y",
-    "width",
-    "height",
+    'x',
+    'y',
+    'width',
+    'height',
     alpha=1.0,
     fill_alpha=0.2,
-    color="black",
+    color='black',
     line_width=3,
     source=sectordata,
 )
-tool = BoxEditTool(
-    renderers=[isector], num_objects=len(COLORS)
-)  # allow only as many boxes as Colors
+tool = BoxEditTool(renderers=[isector], num_objects=len(COLORS))  # allow only as many boxes as Colors
 bf_plot.add_tools(tool)
-sectordata.on_change("data", integrate_result)
-bv.cdsource.on_change(
-    "data", integrate_result
-)  # also change integration result when source map changes
+sectordata.on_change('data', integrate_result)
+bv.cdsource.on_change('data', integrate_result)  # also change integration result when source map changes
 
 # %% Instructions
 
@@ -507,7 +495,7 @@ right_layout = column(
     setting_selector,
     Spacer(height=20),
     selected_setting_col,
-    sizing_mode="stretch_width",
+    sizing_mode='stretch_width',
 )
 instructions_col = column(instruction_calculation, instruction_sector_integration)
 layout = column(


### PR DESCRIPTION
# Summary
- update `pyproject.toml` so `src/spectacoular/apps/bf_example_app/` is no longer excluded from Ruff
- add a package docstring in `src/spectacoular/apps/__init__.py`
- clean up `src/spectacoular/apps/bf_example_app/__init__.py`
- fix Ruff findings in `src/spectacoular/apps/bf_example_app/main.py`

## Main code cleanups in the app
- rename mixed-case globals and callbacks to snake_case
- add/fix docstrings
- replace `list(...)[0]` with `next(iter(...))`
- mark unused callback args explicitly
- replace one magic threshold with a named constant
- wrap long UI instruction strings
- remove the `print(...)` call in the standalone launcher
- keep targeted inline suppressions only where the current API intentionally requires them

# Issue linkage
#39 