### PR TITLE
Clean up `data_viewer_app` for Ruff compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,11 @@ extend-exclude = [
     "docs/conf.py",
     "examples",
     "tests",
-    "src/spectacoular/apps",
+    "src/spectacoular/apps/bf_example_app",
+    "src/spectacoular/apps/level_meter_app",
+    "src/spectacoular/apps/measurement_app",
+    "src/spectacoular/apps/micgeom_app",
+    "src/spectacoular/apps/rotating_example_app",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/spectacoular/apps/__init__.py
+++ b/src/spectacoular/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Bokeh application entry points shipped with SpectAcoular."""

--- a/src/spectacoular/apps/data_viewer_app/__init__.py
+++ b/src/spectacoular/apps/data_viewer_app/__init__.py
@@ -1,9 +1,12 @@
-import sys
+"""Bokeh entry point for the data viewer application."""
+
 import subprocess
+import sys
 from pathlib import Path
 
 
 def main():
-    command = ["bokeh", "serve", Path(__file__).parent]
+    """Start the data viewer as a Bokeh server application."""
+    command = ['bokeh', 'serve', Path(__file__).parent]
     command.extend(sys.argv[1:])
-    subprocess.run(command)
+    subprocess.run(command, check=False)  # noqa: S603

--- a/src/spectacoular/apps/data_viewer_app/main.py
+++ b/src/spectacoular/apps/data_viewer_app/main.py
@@ -47,13 +47,11 @@ line_opts = {
 }
 
 # build processing chain
-ts = sp.MaskedTimeSamples(file=Path(__file__).parent.parent / "example_data.h5")
+ts = sp.MaskedTimeSamples(file=Path(__file__).parent.parent / 'example_data.h5')
 tv = sp.TimeSamplesPresenter(
     source=ts,
     _numsubsamples=1000,
-    cdsource=ColumnDataSource(
-        data={"xs": [], "ys": [], "ch": [], "color": [], "sizes": []}
-    ),
+    cdsource=ColumnDataSource(data={'xs': [], 'ys': [], 'ch': [], 'color': [], 'sizes': []}),
 )
 tio = ac.MaskedTimeOut(source=ts, invalid_channels=[])
 ps = sp.PowerSpectra(source=tio, cached=False)
@@ -61,7 +59,7 @@ freqdata = ColumnDataSource(data={'amp': [[0]], 'freqs': [[0]], 'chn': [[0]], 'c
 
 # create widget to select the channel that should be plotted
 mselect = MultiSelect(
-    title="Select Channel:",
+    title='Select Channel:',
     value=[],
     height=250,
     options=[(str(i), str(i)) for i in range(ts.num_channels)],
@@ -76,9 +74,7 @@ time_range = RangeSlider(
     step=1000,
     title='Time Range',
 )
-linesize_slider = Slider(
-    start=0.0, end=5, value=2.0, step=0.05, title='Line Size', disabled=False
-)
+linesize_slider = Slider(start=0.0, end=5, value=2.0, step=0.05, title='Line Size', disabled=False)
 
 
 def update_linesize(_attr, _old, _new):
@@ -198,7 +194,7 @@ def change_selectable_channels():
     freqdata.data = {'amp': [[0]], 'freqs': [[0]], 'chn': [[0]], 'color': [0]}
 
 
-ts.on_trait_change(change_selectable_channels, "num_channels")
+ts.on_trait_change(change_selectable_channels, 'num_channels')
 
 # TimeSignalPlot
 timeplottips = [('Channel Index', '@ch'), ('Sample', '$x'), ('p', '$y')]
@@ -215,25 +211,23 @@ ts_plot.multi_line(xs='xs', ys='ys', line_width='sizes', source=tv.cdsource, **l
 
 # FrequencySignalPlot
 freqplottips = [
-    ("Channel", "@chn"),
-    ("Frequency in Hz", "$x"),
-    ("|P(f)|^2 in dB", "$y"),
+    ('Channel', '@chn'),
+    ('Frequency in Hz', '$x'),
+    ('|P(f)|^2 in dB', '$y'),
 ]
 freqplot = figure(
-    title="Auto Power Spectra",
+    title='Auto Power Spectra',
     width=1500,
     height=800,
-    x_axis_type="log",
-    x_axis_label="f in Hz",
-    y_axis_label="|P(f)|^2 / dB",
+    x_axis_type='log',
+    x_axis_label='f in Hz',
+    y_axis_label='|P(f)|^2 / dB',
     tooltips=freqplottips,
     x_range=(40, 26000),
 )
 freqplot.toolbar.logo = None
-freqplot.xaxis.ticker, freqplot.xaxis.major_label_overrides = get_logticks(
-    [10, 30000], unit="Hz"
-)
-freqplot.multi_line(xs="freqs", ys="amp", line_width=3, source=freqdata, **line_opts)
+freqplot.xaxis.ticker, freqplot.xaxis.major_label_overrides = get_logticks([10, 30000], unit='Hz')
+freqplot.multi_line(xs='freqs', ys='amp', line_width=3, source=freqdata, **line_opts)
 # create layout
 ts_widgets_col = column(plot_button, mselect, *ts_widgets.values(), width=200)
 ps_widgets_col = column(plot_button, mselect, *list(ps_widgets.values()), width=200)

--- a/src/spectacoular/apps/data_viewer_app/main.py
+++ b/src/spectacoular/apps/data_viewer_app/main.py
@@ -9,41 +9,42 @@ Start from an installed package with:
     data_viewer_app --show
 """
 
+from pathlib import Path
+
 import acoular as ac
 import spectacoular as sp
-import numpy as np
 
-from pathlib import Path
+import numpy as np
 
 # bokeh imports
 from bokeh.io import curdoc
-from bokeh.layouts import row, column
-from bokeh.models import ColumnDataSource
-from bokeh.models import Tabs, TabPanel as Panel
+from bokeh.layouts import column, row
+from bokeh.models import ColumnDataSource, Tabs
+from bokeh.models import TabPanel as Panel
 from bokeh.models.widgets import (
-    Toggle,
-    TextInput,
     Button,
-    PreText,
     MultiSelect,
+    PreText,
     RangeSlider,
     Slider,
+    TextInput,
+    Toggle,
 )
-from bokeh.plotting import figure
 from bokeh.palettes import Turbo256
+from bokeh.plotting import figure
 from bokeh.server.server import Server
 
-
-COLORS = np.array(Turbo256)  # for plotting different colors
-np.random.shuffle(COLORS)
+rng = np.random.default_rng()
+colors = np.array(Turbo256)  # for plotting different colors
+rng.shuffle(colors)
 doc = curdoc()
 
-line_opts = dict(
-    line_color="color",
-    line_alpha=0.6,
-    hover_line_color="color",
-    hover_line_alpha=1.0,
-)
+line_opts = {
+    'line_color': 'color',
+    'line_alpha': 0.6,
+    'hover_line_color': 'color',
+    'hover_line_alpha': 1.0,
+}
 
 # build processing chain
 ts = sp.MaskedTimeSamples(file=Path(__file__).parent.parent / "example_data.h5")
@@ -56,7 +57,7 @@ tv = sp.TimeSamplesPresenter(
 )
 tio = ac.MaskedTimeOut(source=ts, invalid_channels=[])
 ps = sp.PowerSpectra(source=tio, cached=False)
-freqdata = ColumnDataSource(data=dict(amp=[[0]], freqs=[[0]], chn=[[0]], color=[[0]]))
+freqdata = ColumnDataSource(data={'amp': [[0]], 'freqs': [[0]], 'chn': [[0]], 'color': [[0]]})
 
 # create widget to select the channel that should be plotted
 mselect = MultiSelect(
@@ -67,148 +68,150 @@ mselect = MultiSelect(
 )
 
 # create Button to trigger plot
-plotButton = Toggle(label="Plot Data", button_type="primary")
-timeRange = RangeSlider(
+plot_button = Toggle(label='Plot Data', button_type='primary')
+time_range = RangeSlider(
     start=ts.start,
     end=ts.num_samples,
     value=(0, ts.num_samples),
     step=1000,
-    title="Time Range",
+    title='Time Range',
 )
-linesizeSlider = Slider(
-    start=0.0, end=5, value=2.0, step=0.05, title="Line Size", disabled=False
+linesize_slider = Slider(
+    start=0.0, end=5, value=2.0, step=0.05, title='Line Size', disabled=False
 )
 
 
-def update_linesize(attr, old, new):
-    tv.cdsource.data["sizes"] = np.array([linesizeSlider.value] * len(tv.channels))
+def update_linesize(_attr, _old, _new):
+    """Update the line widths in the time-series plot."""
+    tv.cdsource.data['sizes'] = np.array([linesize_slider.value] * len(tv.channels))
 
 
-linesizeSlider.on_change("value", update_linesize)
+linesize_slider.on_change('value', update_linesize)
 
 # get widgets to control settings
-tsWidgets = ts.get_widgets()
-tsWidgets.pop("invalid_channels")
-psWidgets = ps.get_widgets()
+ts_widgets = ts.get_widgets()
+ts_widgets.pop('invalid_channels')
+ps_widgets = ps.get_widgets()
 
 
-def file_change_callback(attr, old, new):
-    timeRange.start = ts.start
+def file_change_callback(_attr, _old, _new):
+    """Update the time-range widget after the source file changes."""
+    time_range.start = ts.start
     if ts.stop:
-        timeRange.end = ts.stop
+        time_range.end = ts.stop
     else:
-        timeRange.end = ts.numsamples
-    timeRange.value = (timeRange.start, timeRange.end)
+        time_range.end = ts.numsamples
+    time_range.value = (time_range.start, time_range.end)
 
 
-tsWidgets["file"].on_change("value", file_change_callback)
+ts_widgets['file'].on_change('value', file_change_callback)
 
 
-# THIS FUNCTION GENERATES THE TICKS (TO MOVE)
-def get_logticks(frange=[100, 10000], minor_ticks=[5, 2, 7], unit="kHz"):
+def get_logticks(frange=None, minor_ticks=None, unit='kHz'):
+    """Return logarithmic ticks and matching labels for a frequency axis."""
+    if frange is None:
+        frange = [100, 10000]
+    if minor_ticks is None:
+        minor_ticks = [5, 2, 7]
     scales = int(np.log10(frange[1])) - int(np.log10(frange[0])) + 1
-    # start with major ticks
     ticks = np.logspace(int(np.log10(frange[0])), int(np.log10(frange[1])), num=scales)
-    for n in minor_ticks:
-        ticks = np.append(ticks, ticks[:scales] * n)
-        ticks = ticks[frange[0] <= ticks]  # lower bound
-        ticks = ticks[ticks <= frange[1]]  # upper bound
+    for factor in minor_ticks:
+        ticks = np.append(ticks, ticks[:scales] * factor)
+        ticks = ticks[frange[0] <= ticks]
+        ticks = ticks[ticks <= frange[1]]
     ticks = list(np.sort(ticks))
-    if unit == "kHz":
-        d = 1000
-    else:
-        d = 1
-    override = dict()
+    divisor = 1000 if unit == 'kHz' else 1
+    override = {}
     for tick in ticks:
-        override[str(int(tick))] = str(tick / d)
+        override[str(int(tick))] = str(tick / divisor)
     return ticks, override
 
 
 def get_spectra():
-    r_sel, freq, chn, color = [], [], [], []
-    for sel in mselect.value:
-        sel = int(sel)
-        mask_idx = [i for i in range(ts.num_channels) if not i == sel]
-        tio.invalid_channels = mask_idx  # don't calculate unused spectra
+    """Calculate and display spectra for the selected channels."""
+    selected_results, freqs, channels, plot_colors = [], [], [], []
+    for selected_channel_value in mselect.value:
+        selected_channel = int(selected_channel_value)
+        mask_idx = [i for i in range(ts.num_channels) if i != selected_channel]
+        tio.invalid_channels = mask_idx
         result = ac.L_p(np.real(ps.csm[:, 0, 0]))
-        r_sel.append(result)  # multiselect ColumnDataSource expects a list of lists
-        freq.append(ps.fftfreq())
-        chn.append([sel])
-        color.append(COLORS[sel])
-    freqdata.data.update(amp=r_sel, freqs=freq, chn=chn, color=color)
-    freqplot.x_range.start = freq[0][1] - 20
-    freqplot.x_range.end = freq[0][-1] + 20
+        selected_results.append(result)
+        freqs.append(ps.fftfreq())
+        channels.append([selected_channel])
+        plot_colors.append(colors[selected_channel])
+    freqdata.data.update(amp=selected_results, freqs=freqs, chn=channels, color=plot_colors)
+    freqplot.x_range.start = freqs[0][1] - 20
+    freqplot.x_range.end = freqs[0][-1] + 20
 
 
 if ac.config.have_sounddevice:  # in case of audio support
     import sounddevice as sd
 
     playback = sp.TimeSamplesPlayback(source=ts)
-    # button widget to playback the selected time data
-    playButton = Toggle(label="Playback Time Data", button_type="primary")
-    # Input Device Textfield
-    inputDevice = TextInput(title="Input Index", value=str(playback.device[0]))
-    # Output Device Textfield
-    outputDevice = TextInput(title="Output Index", value=str(playback.device[1]))
-    # QueryDevices
-    queryButton = Button(label="QueryDevices")
-    queryOutput = PreText(width=500, height=400)
+    play_button = Toggle(label='Playback Time Data', button_type='primary')
+    input_device = TextInput(title='Input Index', value=str(playback.device[0]))
+    output_device = TextInput(title='Output Index', value=str(playback.device[1]))
+    query_button = Button(label='QueryDevices')
+    query_output = PreText(width=500, height=400)
 
-    def set_input_device(attr, old, new):
+    def set_input_device(_attr, _old, new):
+        """Update the selected audio input device."""
         playback.device = [int(new), playback.device[1]]
 
-    inputDevice.on_change("value", set_input_device)
+    input_device.on_change('value', set_input_device)
 
-    def set_output_device(attr, old, new):
+    def set_output_device(_attr, _old, new):
+        """Update the selected audio output device."""
         playback.device = [playback.device[0], int(new)]
 
-    outputDevice.on_change("value", set_output_device)
+    output_device.on_change('value', set_output_device)
 
     def print_devices():
-        queryOutput.text = f"{sd.query_devices()}"
+        """Show the available audio devices."""
+        query_output.text = f'{sd.query_devices()}'
 
-    queryButton.on_click(print_devices)
+    query_button.on_click(print_devices)
 
-    # playback.set_widgets(**{'channels': tselect})
-
-    def playButton_handler(arg):
-        if arg:
+    def play_button_handler(active):
+        """Start or stop playback of the selected channels."""
+        if active:
             playback.channels = [int(v) for v in mselect.value]
             playback.play()
-        elif not arg:
+        else:
             playback.stop()
 
-    playButton.on_click(playButton_handler)
+    play_button.on_click(play_button_handler)
 
-    pbWidgetCol = column(
-        playButton,
-        row(inputDevice, outputDevice, width=200),
-        queryButton,
-        queryOutput,
+    pb_widget_col = column(
+        play_button,
+        row(input_device, output_device, width=200),
+        query_button,
+        query_output,
         width=200,
     )
 
 
 def change_selectable_channels():
+    """Refresh the list of selectable channels and reset spectral data."""
     channels = [str(idx) for idx in range(ts.num_channels)]
     mselect.options = [(i, i) for i in channels]
-    freqdata.data = dict(amp=[[0]], freqs=[[0]], chn=[[0]], color=[0])
+    freqdata.data = {'amp': [[0]], 'freqs': [[0]], 'chn': [[0]], 'color': [0]}
 
 
 ts.on_trait_change(change_selectable_channels, "num_channels")
 
 # TimeSignalPlot
-timeplottips = [("Channel Index", "@ch"), ("Sample", "$x"), ("p", "$y")]
-tsPlot = figure(
-    title="Time Signals",
+timeplottips = [('Channel Index', '@ch'), ('Sample', '$x'), ('p', '$y')]
+ts_plot = figure(
+    title='Time Signals',
     width=1500,
     height=800,
-    x_axis_label="sample index",
-    y_axis_label="p [Pa]",
+    x_axis_label='sample index',
+    y_axis_label='p [Pa]',
     tooltips=timeplottips,
 )
-tsPlot.toolbar.logo = None
-tsPlot.multi_line(xs="xs", ys="ys", line_width="sizes", source=tv.cdsource, **line_opts)
+ts_plot.toolbar.logo = None
+ts_plot.multi_line(xs='xs', ys='ys', line_width='sizes', source=tv.cdsource, **line_opts)
 
 # FrequencySignalPlot
 freqplottips = [
@@ -232,57 +235,59 @@ freqplot.xaxis.ticker, freqplot.xaxis.major_label_overrides = get_logticks(
 )
 freqplot.multi_line(xs="freqs", ys="amp", line_width=3, source=freqdata, **line_opts)
 # create layout
-tsWidgetsCol = column(plotButton, mselect, *tsWidgets.values(), width=200)
-psWidgetsCol = column(plotButton, mselect, *list(psWidgets.values()), width=200)
+ts_widgets_col = column(plot_button, mselect, *ts_widgets.values(), width=200)
+ps_widgets_col = column(plot_button, mselect, *list(ps_widgets.values()), width=200)
 if ac.config.have_sounddevice:
-    timeDataLayout = row(tsWidgetsCol, pbWidgetCol, width=200)
-    freqDataLayout = row(psWidgetsCol, pbWidgetCol, width=200)
+    time_data_layout = row(ts_widgets_col, pb_widget_col, width=200)
+    freq_data_layout = row(ps_widgets_col, pb_widget_col, width=200)
 else:
-    timeDataLayout = row(tsWidgetsCol, width=100)
-    freqDataLayout = row(psWidgetsCol, width=100)
+    time_data_layout = row(ts_widgets_col, width=100)
+    freq_data_layout = row(ps_widgets_col, width=100)
 
 
 # Put in Tabs
-tsTab = Panel(
-    child=row(column(linesizeSlider, timeRange, tsPlot), timeDataLayout),
-    title="Time Data",
+ts_tab = Panel(
+    child=row(column(linesize_slider, time_range, ts_plot), time_data_layout),
+    title='Time Data',
 )
-fdTab = Panel(child=row(freqplot, freqDataLayout), title="Frequency Data")
-plotTab = Tabs(tabs=[tsTab, fdTab])
+fd_tab = Panel(child=row(freqplot, freq_data_layout), title='Frequency Data')
+plot_tab = Tabs(tabs=[ts_tab, fd_tab])
 
 
 def plot():
-    if plotTab.active == 0:
+    """Plot either the selected time signals or the selected spectra."""
+    if plot_tab.active == 0:
         tv.channels = [int(v) for v in mselect.value]
-        tv.update(**{"color": [COLORS[int(v)] for v in mselect.value]})
-    elif plotTab.active == 1:
+        tv.update(color=[colors[int(v)] for v in mselect.value])
+    elif plot_tab.active == 1:
         get_spectra()
-        get_logticks([10, 30000], unit="Hz")
+        get_logticks([10, 30000], unit='Hz')
 
 
-sp.set_calc_button_callback(plot, plotButton, label="Plot Data")
+sp.set_calc_button_callback(plot, plot_button, label='Plot Data')
 
 
-def time_range_callback(attr, old, new):
-    ts.start = timeRange.value[0]
-    ts.stop = timeRange.value[1]
+def time_range_callback(_attr, _old, _new):
+    """Update the selected time window and refresh the plot."""
+    ts.start = time_range.value[0]
+    ts.stop = time_range.value[1]
     plot()
 
 
-timeRange.on_change("value_throttled", time_range_callback)
+time_range.on_change('value_throttled', time_range_callback)
 
 
 # make Document
 def server_doc(doc):
-    doc.add_root(plotTab)
-    doc.title = "Time Signal Exploration App"
+    """Add the data viewer layout to a Bokeh document."""
+    doc.add_root(plot_tab)
+    doc.title = 'Time Signal Exploration App'
 
 
-if __name__ == "__main__":
-    server = Server({"/": server_doc})
+if __name__ == '__main__':
+    server = Server({'/': server_doc})
     server.start()
-    print("Opening application on http://localhost:5006/")
-    server.io_loop.add_callback(server.show, "/")
+    server.io_loop.add_callback(server.show, '/')
     server.io_loop.start()
 else:
     doc = curdoc()


### PR DESCRIPTION
# Summary
- update `pyproject.toml` so `src/spectacoular/apps/data_viewer_app/` is included in Ruff checks
- add a package docstring in `src/spectacoular/apps/__init__.py`
- clean up `src/spectacoular/apps/data_viewer_app/__init__.py`
- fix Ruff findings in `src/spectacoular/apps/data_viewer_app/main.py`

## Main app cleanups
- rename mixed-case globals, widgets, and callbacks to snake_case
- add/fix docstrings
- replace legacy RNG usage with `np.random.default_rng()`
- replace `dict(...)` calls with literals
- avoid mutable default arguments
- mark unused callback args explicitly
- simplify small control-flow issues
- remove the `print(...)` call in the standalone launcher
- keep only targeted inline suppressions where the current API still requires them

# Issue linkage
#39