### PR TITLE
Fix/calib helper physics2

### DIFF
--- a/src/spectacoular/lprocess.py
+++ b/src/spectacoular/lprocess.py
@@ -163,8 +163,8 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
     #: automatically generated from a time stamp.
     file = File(filter=['*.xml'], desc='name of data file')
 
-    #: calibration level (e. g. dB or Pa) of calibration device
-    magnitude = Float(114, desc='calibration level of calibration device')
+    #: calibration level  dB  
+   calibration_level_db = Float(114, desc='calibration level of calibration device in dB')
 
     #: calibration values determined during evaluation of :meth:`result`.
     #: array of floats with dimension (num_channels, 2)
@@ -180,11 +180,11 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
     #: channel-wise allowed standard deviation of calibration values in buffer
     calibstd = Float(0.5, desc='allowed standard deviation of calibration values in buffer')
 
-    #: minimum allowed difference in magnitude between the channel to be
+    #: minimum allowed difference of level in dB between the channel to be
     #: calibrated and remaining channels.
     delta = Float(
         10,
-        desc='magnitude difference between calibrating channel and remaining channels',
+        desc='calibration_level_db difference between calibrating channel and remaining channels',
     )
 
     # internal identifier
@@ -192,7 +192,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
 
     trait_widget_mapper: ClassVar[dict[str, type]] = {
         'file': TextInput,
-        'magnitude': NumericInput,
+        'calibration_level_db': NumericInput,
         'buffer_size': NumericInput,
         'calibstd': NumericInput,
         'delta': NumericInput,
@@ -200,7 +200,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
 
     trait_widget_args: ClassVar[dict[str, dict[str, object]]] = {
         'file': {'disabled': False},
-        'magnitude': {'disabled': False, 'mode': 'float'},
+        'calibration_level_db': {'disabled': False, 'mode': 'float'},
         'buffer_size': {'disabled': False, 'mode': 'int'},
         'calibstd': {'disabled': False, 'mode': 'float'},
         'delta': {'disabled': False, 'mode': 'float'},
@@ -265,8 +265,8 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
             buffer[0:bufferidx] = buffer[-bufferidx:]  # copy remaining samples in front of next block
             buffer[-ns:, :] = ac.L_p(temp)
             calibmask = np.logical_and(
-                buffer > (self.magnitude - self.delta),
-                buffer < (self.magnitude + self.delta),
+                buffer > (self.calibration_level_db - self.delta),
+                buffer < (self.calibration_level_db + self.delta),
             ).sum(0)
             # print(calibmask)
             if (calibmask.max() == self.buffer_size) and (calibmask.sum() == self.buffer_size):
@@ -274,12 +274,12 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
                 # print(buffer[:,idx].std())
                 if buffer[:, idx].std() < self.calibstd:
                     calibdata = self.calibdata.copy()
-                    calibdata[idx, :] = [np.mean(buffer[:, idx]), self.magnitude]
-                    # self.calibdata[idx,:] = [mean(L_p(buffer[:,idx])), self.magnitude]
+                    calibdata[idx, :] = [np.mean(buffer[:, idx]), self.calibration_level_db]
+                    # self.calibdata[idx,:] = [mean(L_p(buffer[:,idx])), self.calibration_level_db]
                     self.calibdata = calibdata
 
             for i in np.arange(self.num_channels):
-                self.calibfactor[i] = self.to_pa(self.magnitude) / self.to_pa(float(self.calibdata[i, 0]))
+                self.calibfactor[i] = self.to_pa(self.calibration_level_db) / self.to_pa(float(self.calibdata[i, 0]))
             yield temp
 
 

--- a/src/spectacoular/lprocess.py
+++ b/src/spectacoular/lprocess.py
@@ -164,7 +164,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
     file = File(filter=['*.xml'], desc='name of data file')
 
     #: calibration level  dB  
-   calibration_level_db = Float(114, desc='calibration level of calibration device in dB')
+    calibration_level_db = Float(114, desc='calibration level of calibration device in dB')
 
     #: calibration values determined during evaluation of :meth:`result`.
     #: array of floats with dimension (num_channels, 2)
@@ -263,19 +263,21 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
             ns = temp.shape[0]
             bufferidx = self.buffer_size - ns
             buffer[0:bufferidx] = buffer[-bufferidx:]  # copy remaining samples in front of next block
-            buffer[-ns:, :] = ac.L_p(temp)
+            buffer[-ns:, :] = temp
+            level_buffer = ac.L_p(buffer)
             calibmask = np.logical_and(
-                buffer > (self.calibration_level_db - self.delta),
-                buffer < (self.calibration_level_db + self.delta),
+                level_buffer > (self.calibration_level_db - self.delta),
+                level_buffer < (self.calibration_level_db + self.delta),
             ).sum(0)
             # print(calibmask)
             if (calibmask.max() == self.buffer_size) and (calibmask.sum() == self.buffer_size):
                 idx = calibmask.argmax()
                 # print(buffer[:,idx].std())
-                if buffer[:, idx].std() < self.calibstd:
+                if level_buffer[:, idx].std() < self.calibstd:
+                    mean_power = np.mean(buffer[:, idx])
+                    measured_level_db = ac.L_p(mean_power)
                     calibdata = self.calibdata.copy()
-                    calibdata[idx, :] = [np.mean(buffer[:, idx]), self.calibration_level_db]
-                    # self.calibdata[idx,:] = [mean(L_p(buffer[:,idx])), self.calibration_level_db]
+                    calibdata[idx, :] = [measured_level_db, self.calibration_level_db]
                     self.calibdata = calibdata
 
             for i in np.arange(self.num_channels):

--- a/src/spectacoular/lprocess.py
+++ b/src/spectacoular/lprocess.py
@@ -208,7 +208,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
 
     def to_pa(self, level):
         """Convert a sound level to pressure in pascal."""
-        return (10 ** (level / 10)) * (4e-10)
+        return (10 ** (level / 20)) * (2e-5)
 
     @cached_property
     def _get_digest(self):

--- a/src/spectacoular/lprocess.py
+++ b/src/spectacoular/lprocess.py
@@ -163,8 +163,8 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
     #: automatically generated from a time stamp.
     file = File(filter=['*.xml'], desc='name of data file')
 
-    #: calibration level  dB  
-    calibration_level_db = Float(114, desc='calibration level of calibration device in dB')
+    #: calibration level in dB
+    magnitude = Float(114, desc='sound-pressure level produced by the calibration device in dB')
 
     #: calibration values determined during evaluation of :meth:`result`.
     #: array of floats with dimension (num_channels, 2)
@@ -184,7 +184,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
     #: calibrated and remaining channels.
     delta = Float(
         10,
-        desc='calibration_level_db difference between calibrating channel and remaining channels',
+        desc='magnitude difference between calibrating channel and remaining channels',
     )
 
     # internal identifier
@@ -192,7 +192,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
 
     trait_widget_mapper: ClassVar[dict[str, type]] = {
         'file': TextInput,
-        'calibration_level_db': NumericInput,
+        'magnitude': NumericInput,
         'buffer_size': NumericInput,
         'calibstd': NumericInput,
         'delta': NumericInput,
@@ -200,7 +200,7 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
 
     trait_widget_args: ClassVar[dict[str, dict[str, object]]] = {
         'file': {'disabled': False},
-        'calibration_level_db': {'disabled': False, 'mode': 'float'},
+        'magnitude': {'disabled': False, 'mode': 'float'},
         'buffer_size': {'disabled': False, 'mode': 'int'},
         'calibstd': {'disabled': False, 'mode': 'float'},
         'delta': {'disabled': False, 'mode': 'float'},
@@ -266,8 +266,8 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
             buffer[-ns:, :] = temp
             level_buffer = ac.L_p(buffer)
             calibmask = np.logical_and(
-                level_buffer > (self.calibration_level_db - self.delta),
-                level_buffer < (self.calibration_level_db + self.delta),
+                level_buffer > (self.magnitude - self.delta),
+                level_buffer < (self.magnitude + self.delta),
             ).sum(0)
             # print(calibmask)
             if (calibmask.max() == self.buffer_size) and (calibmask.sum() == self.buffer_size):
@@ -277,11 +277,11 @@ class CalibHelper(ac.TimeOut, BaseSpectacoular):
                     mean_power = np.mean(buffer[:, idx])
                     measured_level_db = ac.L_p(mean_power)
                     calibdata = self.calibdata.copy()
-                    calibdata[idx, :] = [measured_level_db, self.calibration_level_db]
+                    calibdata[idx, :] = [measured_level_db, self.magnitude]
                     self.calibdata = calibdata
 
             for i in np.arange(self.num_channels):
-                self.calibfactor[i] = self.to_pa(self.calibration_level_db) / self.to_pa(float(self.calibdata[i, 0]))
+                self.calibfactor[i] = self.to_pa(self.magnitude) / self.to_pa(float(self.calibdata[i, 0]))
             yield temp
 
 


### PR DESCRIPTION
<!-- 
Thank you so much for contributing a pull request! Please ensure
that your pull request satisfies the checklist before submitting:
https://acoular.org/contributing/checklist.html

If you are part the of Acoular development team, please make sure to
select a label for this pull request on the sidebar to the right.

Check out the milestones here: https://github.com/acoular/spectacoular/milestones

Again, thanks for contributing!
-->

### Description
Ccorrected the SPL-to-pressure conversion :
  `2e-5 * 10 ^(level_db / 20)`;
- replaced the  `magnitude` attribute with `calibration_level_db`;
- added a new buffer level_buffer for having a value in dB of the buffer
- kept the calibration buffer in the linear power domain;
- changed the calibration-level calculation so that power values are averaged before the result is converted to dB.


### Reference issue
BUG: Incorrect calibration in measurement_app #71 can be closed as #4 is actually workin correctly 

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [ X] I have read the [Contributing](https://acoular.org/contributing/index.html) section.
- [X ] My branch is up-to-date with the *master* branch of the [SpectAcoular repository](https://github.com/acoular/spectacoular).
- [ X] My changes fulfill the [Code Quality](https://acoular.org/contributing/quality.html) standards.
- [ ] I have updated the [What's new](https://github.com/acoular/spectacoular/blob/master/docs/source/news/index.rst) section explaining my changes. --> **link does not work** 
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/spectacoular/blob/master/CITATION.cff) file.
